### PR TITLE
Bmp280 math fix and MPU6050 fixes

### DIFF
--- a/main/helpers/CMakeLists.txt
+++ b/main/helpers/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_library(helpers
  timer.c
- math.c)
+ math.c
+ rotation_matrix.c)

--- a/main/helpers/math.c
+++ b/main/helpers/math.c
@@ -31,6 +31,7 @@ void mat_mult(float a[], float b[], float out[]){
 	
 	for(int i = 0; i < 3; i++){
 		for(int j = 0; j < 3; j++){
+			out[3*i+j] = 0;
 			for(int k = 0; k < 3; k++){
 				out[3*i+j] += a[3*i+k]*b[3*k+j];
 			}
@@ -42,6 +43,7 @@ void mat_mult_mat_transp(float a[], float b[], float out[]){
 	
 	for(int i = 0; i < 3; i++){
 		for(int j = 0; j < 3; j++){
+			out[3*i+j] = 0;
 			for(int k = 0; k < 3; k++){
 				out[3*i+j] += a[3*i+k]*b[3*j+k];
 			}

--- a/main/helpers/math.h
+++ b/main/helpers/math.h
@@ -1,6 +1,8 @@
 
 #ifndef HELPERS_KITEMATH
 #define HELPERS_KITEMATH
+
+#include <math.h>
  
 float safe_acos(float number_more_or_less_between_one_and_minus_one);
 

--- a/main/helpers/rotation_matrix.c
+++ b/main/helpers/rotation_matrix.c
@@ -1,0 +1,75 @@
+#include "rotation_matrix.h"
+
+// COORDINATE SYSTEM OF MPU (in vector subtraction notation):
+// X-Axis: GYRO chip - FUTURE silk writing
+// Y-Axis: BMP chip - BATTERY CONNECTORS
+// Z-Axis: custom board - ESP32 board
+
+// COORDINATE SYSTEM OF KITE (in vector subtraction notation):
+// X-Axis: head - tail
+// Y-Axis: left wing - right wing
+// Z-Axis: kite - ground station
+
+#define accel_x -position.accel[1]
+#define accel_y position.accel[0]
+#define accel_z position.accel[2]
+
+#define gyro_x -position.gyro[1]
+#define gyro_y position.gyro[0]
+#define gyro_z position.gyro[2]
+
+#define gravity_x 1
+#define gravity_y 0
+#define gravity_z 0
+
+// rotation of the drone in world coordinates
+float rotation_matrix[9] = {1, 0, 0, 0, 1, 0, 0, 0, 1};
+
+struct position_data position = {
+	{0, 0, 0},
+	{0, 0, 0}
+};
+
+Time mpu_last_update_time = 0;
+
+void updateRotationMatrix(){
+	readMPUData(&position);
+	if(mpu_last_update_time == 0){
+		mpu_last_update_time = start_timer();
+		return;
+	}
+	float time_difference = query_timer_seconds(mpu_last_update_time);
+	mpu_last_update_time = start_timer();
+	
+	// matrix based:
+	// rotation-matrix:
+	// angles in radians
+	// 0.01745329 = pi/180
+	float alpha = 0.01745329 * gyro_x * time_difference;
+	float beta = 0.01745329 * gyro_y * time_difference;
+	float gamma = 0.01745329 * gyro_z * time_difference;
+	
+	// infinitesimal rotation matrix:
+	float diff[9];
+	diff[0] = 1; //maybe can replace by 1 here
+	diff[1] = -sin(gamma);
+	diff[2] = sin(beta);
+	
+	diff[3] = sin(gamma);
+	diff[4] = 1;
+	diff[5] = -sin(alpha);
+	
+	diff[6] = -sin(beta);
+	diff[7] = sin(alpha);
+	diff[8] = 1;
+	
+	float temp_rotation_matrix[9];
+	mat_mult(rotation_matrix, diff, temp_rotation_matrix);
+	
+	rotate_towards_g(temp_rotation_matrix, gravity_x, gravity_y, gravity_z, accel_x, accel_y, accel_z, rotation_matrix);
+	//memcpy(rotation_matrix, temp_rotation_matrix, sizeof(temp_rotation_matrix));// TODO: remove when above line uncommented!!!
+	
+	normalize_matrix(rotation_matrix);
+}
+
+

--- a/main/helpers/rotation_matrix.h
+++ b/main/helpers/rotation_matrix.h
@@ -1,0 +1,14 @@
+#ifndef ROTATION_MATRIX_FILE
+#define ROTATION_MATRIX_FILE
+
+#include <string.h>
+#include "math.h"
+#include "../i2c_devices/mpu6050.h"
+#include "timer.h"
+
+float rotation_matrix[9];
+
+void updateRotationMatrix();
+
+
+#endif

--- a/main/i2c_devices/bmp280.c
+++ b/main/i2c_devices/bmp280.c
@@ -7,17 +7,18 @@
 #define  SMOOTHING_TEMPERATURE_RECENT_VALUE_WEIGHT 0.2
 #define  SMOOTHING_PRESSURE_RECENT_VALUE_WEIGHT 0.2
 #define  INITIAL_MEASUREMENT_CYCLE_COUNT 5
+#define  ONE_DIVIDED_BY_INITIAL_MEASUREMENT_CYCLE_COUNT 0.2
 
-struct i2c_bus bus;
+struct i2c_bus bmp280_bus;
 Time last_update;
 
 void startBmp280Measurement(){
 	// chip_addr, register, precision(0x25 least precise, takes 9 ms, 0x5D most precise, takes 45ms)
-	i2c_send(bus, 0x76, 0xF4, 0x5D, 1);
+	i2c_send(bmp280_bus, 0x76, 0xF4, 0x5D, 1);
   last_update = start_timer();
 }
 
-float dp_by_dt_factor;
+float minus_dp_by_dt_factor;
 float initial_smoothened_temperature = 0;
 float initial_smoothened_pressure = 0;
 float current_smoothened_temperature = 0;
@@ -25,37 +26,46 @@ float current_smoothened_pressure = 0;
 int64_t last_update = 0;
 
 uint32_t getTemperature(){
-	uint8_t highByte = i2c_receive(bus, 0x76, 0xF7, 1); // ToDoLeo: interchip should expose a read-x byte sequence function
-	uint8_t middleByte = i2c_receive(bus, 0x76, 0xF8, 1);
-	uint8_t lowByte = i2c_receive(bus, 0x76, 0xF9, 1);
+	printf("bmp280_bus = %d, %d\n", bmp280_bus.sda, bmp280_bus.scl);
+	uint8_t highByte = i2c_receive(bmp280_bus, 0x76, 0xFA, 1);
+	uint8_t middleByte = i2c_receive(bmp280_bus, 0x76, 0xFB, 1);
+	uint8_t lowByte = i2c_receive(bmp280_bus, 0x76, 0xFC, 1);
+	
 	return (uint32_t)((highByte << 16) | (middleByte << 8) | lowByte);
 }
 
 float getPressure(){
-	uint8_t highByte = i2c_receive(bus, 0x76, 0xFA, 1);
-	uint8_t middleByte = i2c_receive(bus, 0x76, 0xFB, 1);
-	uint8_t lowByte = i2c_receive(bus, 0x76, 0xFC, 1);
+	uint8_t highByte = i2c_receive(bmp280_bus, 0x76, 0xF7, 1); // ToDoLeo: interchip should expose a read-x byte sequence function
+	uint8_t middleByte = i2c_receive(bmp280_bus, 0x76, 0xF8, 1);
+	uint8_t lowByte = i2c_receive(bmp280_bus, 0x76, 0xF9, 1);
 	uint32_t bmp280_raw_pressure_reading = (uint32_t)((highByte << 16) | (middleByte << 8) | lowByte);
   return 1365.3-0.00007555555555*(float)(bmp280_raw_pressure_reading);
 }
 
 int update_bmp280_if_necessary() {
   if (query_timer_microseconds(last_update) >= UPDATE_INTERVAL_MICROSECONDS) {
-    float recent_temperature = (float)getTemperature();
-    float recent_pressure = getPressure();
     
-    current_smoothened_temperature = (recent_temperature * SMOOTHING_TEMPERATURE_RECENT_VALUE_WEIGHT) + (current_smoothened_temperature * (1-SMOOTHING_TEMPERATURE_RECENT_VALUE_WEIGHT));
-    current_smoothened_pressure = (recent_pressure * SMOOTHING_PRESSURE_RECENT_VALUE_WEIGHT) + (current_smoothened_pressure * (1-SMOOTHING_PRESSURE_RECENT_VALUE_WEIGHT));
+    if(current_smoothened_temperature == 0){
+    	current_smoothened_temperature = (float)getTemperature();
+    	current_smoothened_pressure = getPressure();
+    }else{
+    	// For Mathematicians:
+    	// current_smoothened_temperature = 0.2 * (float)getTemperature() + 0.8 * current_smoothened_temperature;
+    	current_smoothened_temperature = ((float)getTemperature() * SMOOTHING_TEMPERATURE_RECENT_VALUE_WEIGHT) + (current_smoothened_temperature * (1-SMOOTHING_TEMPERATURE_RECENT_VALUE_WEIGHT));
+    	current_smoothened_pressure = (getPressure() * SMOOTHING_PRESSURE_RECENT_VALUE_WEIGHT) + (current_smoothened_pressure * (1-SMOOTHING_PRESSURE_RECENT_VALUE_WEIGHT));
 
+    }
+    
     startBmp280Measurement();
     return 1;
   }
   return 0;
 }
 
-void init_bmp28(struct i2c_bus bus_arg, float dp_by_dt){ // ToDoLeo rename to init. Make sure init calls in main don't conflict
-  bus = bus_arg;
-  dp_by_dt_factor = dp_by_dt;
+void init_bmp280(struct i2c_bus bus_arg, float minus_dp_by_dt){ // ToDoLeo rename to init. Make sure init calls in main don't conflict
+  bmp280_bus = bus_arg;
+  
+  minus_dp_by_dt_factor = minus_dp_by_dt;
   vTaskDelay(500);
 
   // Init Value
@@ -63,18 +73,21 @@ void init_bmp28(struct i2c_bus bus_arg, float dp_by_dt){ // ToDoLeo rename to in
   int update_count = 0;
   while (update_count < INITIAL_MEASUREMENT_CYCLE_COUNT) {
     vTaskDelay(5);
-    update_count = update_count + update_bmp280_if_necessary();
+    
+    update_count = update_count + update_bmp280_if_necessary(); // increment by one if update happened
   }
   initial_smoothened_temperature = current_smoothened_temperature;
   initial_smoothened_pressure = current_smoothened_pressure;
 }
 
+// DIFFERENCE IN ATMOSPHERIC PRESSURE SINCE BOOT
 float getPressureDiff(){
   float delta_temperature = current_smoothened_temperature - initial_smoothened_temperature;
   float delta_pressure = current_smoothened_pressure - initial_smoothened_pressure;
-  return delta_pressure + delta_temperature * dp_by_dt_factor;
+  return delta_pressure + delta_temperature * minus_dp_by_dt_factor;
 }
 
+// HEIGHT DIFFERENCE SINCE BOOT AS MEASURED USING ATMOSPHERIC PRESSURE
 float getHeight() {
   return -10 * getPressureDiff();
 }

--- a/main/i2c_devices/bmp280.c
+++ b/main/i2c_devices/bmp280.c
@@ -26,7 +26,7 @@ float current_smoothened_pressure = 0;
 int64_t last_update = 0;
 
 uint32_t getTemperature(){
-	printf("bmp280_bus = %d, %d\n", bmp280_bus.sda, bmp280_bus.scl);
+	//printf("bmp280_bus = %d, %d\n", bmp280_bus.sda, bmp280_bus.scl);
 	uint8_t highByte = i2c_receive(bmp280_bus, 0x76, 0xFA, 1);
 	uint8_t middleByte = i2c_receive(bmp280_bus, 0x76, 0xFB, 1);
 	uint8_t lowByte = i2c_receive(bmp280_bus, 0x76, 0xFC, 1);

--- a/main/i2c_devices/bmp280.h
+++ b/main/i2c_devices/bmp280.h
@@ -5,9 +5,9 @@
 
 int update_bmp280_if_necessary();
 
-void init_bmp28(struct i2c_bus bus_arg, float dp_by_dt);
+void init_bmp280(struct i2c_bus bus_arg, float dp_by_dt);
 
-float getPressureDiff();
+//float getPressureDiff();
 
 float getHeight();
 

--- a/main/i2c_devices/mpu6050.c
+++ b/main/i2c_devices/mpu6050.c
@@ -77,6 +77,16 @@ void readMPURawData(struct position_data *out){
 	out->accel[2] = accel_precision_factor*(int16_t)((highByte << 8) | lowByte);
 }
 
+void readMPUData(struct position_data *position){
+	readMPURawData(position);
+	position->accel[0] -= mpu_pos_callibration.accel[0];
+	position->accel[1] -= mpu_pos_callibration.accel[1];
+	position->accel[2] -= mpu_pos_callibration.accel[2];
+	position->gyro[0] -= mpu_pos_callibration.gyro[0];
+	position->gyro[1] -= mpu_pos_callibration.gyro[1];
+	position->gyro[2] -= mpu_pos_callibration.gyro[2];
+}
+
 void initMPU6050(struct i2c_bus bus_arg, struct position_data callibration_data){
 	
   bus = bus_arg;

--- a/main/i2c_devices/mpu6050.c
+++ b/main/i2c_devices/mpu6050.c
@@ -8,7 +8,7 @@
 // output acc_calibrationx,y,z preferably via wifi, set accel_offset_* in constants.c to the midpoints between highest and lowest reading.
 
 struct position_data mpu_pos_callibration;
-struct i2c_bus bus;
+struct i2c_bus mpu6050_bus;
 
 float gyro_precision_factor;	//factor needed to get to deg/sec
 float accel_precision_factor;	//factor needed to get to m/s
@@ -19,7 +19,7 @@ float accel_precision_factor;	//factor needed to get to m/s
 //sens = 3 <-> +- 2000 deg/sec
 void init_gyro_sensitivity(int sens){
 	if(sens < 4 && sens >=0){
-		i2c_send(bus, 104, 27, 8*sens, 1);
+		i2c_send(mpu6050_bus, 104, 27, 8*sens, 1);
 		gyro_precision_factor = 250*smallpow(2,sens)/32768.0;
 	}else{
 		printf("setGyroSensitivity(int sens), sensitivity must be between 0 and 3");
@@ -32,7 +32,7 @@ void init_gyro_sensitivity(int sens){
 //sens = 3 <-> +- 16g
 void init_accel_sensitivity(int sens){
 	if(sens < 4 && sens >=0){
-		i2c_send(bus, 104, 28, 8*sens, 1);
+		i2c_send(mpu6050_bus, 104, 28, 8*sens, 1);
 		accel_precision_factor = 2*9.81*smallpow(2,sens)/32768.0;
 	}else{
 		printf("setAccelSensitivity(int sens), sensitivity must be between 0 and 3");
@@ -41,7 +41,7 @@ void init_accel_sensitivity(int sens){
 
 //cut off low frequencies using a Digital Low Pass Filter
 void enableDLPF(){
-	i2c_send(bus, 104, 26, 3, 1);
+	i2c_send(mpu6050_bus, 104, 26, 3, 1);
 }
 
 void readMPURawData(struct position_data *out){
@@ -50,30 +50,30 @@ void readMPURawData(struct position_data *out){
 	
 	//read acc/gyro data at register 59..., 67...
 	//GYRO X
-	highByte = i2c_receive(bus, 104, 67, 1);
-	lowByte = i2c_receive(bus, 104, 68, 1);
+	highByte = i2c_receive(mpu6050_bus, 104, 67, 1);
+	lowByte = i2c_receive(mpu6050_bus, 104, 68, 1);
 	out->gyro[0] = gyro_precision_factor*(int16_t)((highByte << 8) | lowByte);
 	//GYRO Y
-	highByte = i2c_receive(bus, 104, 69, 1);
-	lowByte = i2c_receive(bus, 104, 70, 1);
+	highByte = i2c_receive(mpu6050_bus, 104, 69, 1);
+	lowByte = i2c_receive(mpu6050_bus, 104, 70, 1);
 	out->gyro[1] = gyro_precision_factor*(int16_t)((highByte << 8) | lowByte);
 	//GYRO Z
-	highByte = i2c_receive(bus, 104, 71, 1);
-	lowByte = i2c_receive(bus, 104, 72, 1);
+	highByte = i2c_receive(mpu6050_bus, 104, 71, 1);
+	lowByte = i2c_receive(mpu6050_bus, 104, 72, 1);
 	out->gyro[2] = gyro_precision_factor*(int16_t)((highByte << 8) | lowByte);
 	
   
 	//ACCEL X
-	highByte = i2c_receive(bus, 104, 59, 1);
-	lowByte = i2c_receive(bus, 104, 60, 1);
+	highByte = i2c_receive(mpu6050_bus, 104, 59, 1);
+	lowByte = i2c_receive(mpu6050_bus, 104, 60, 1);
 	out->accel[0] = accel_precision_factor*(int16_t)((highByte << 8) | lowByte);
 	//ACCEL Y
-	highByte = i2c_receive(bus, 104, 61, 1);
-	lowByte = i2c_receive(bus, 104, 62, 1);
+	highByte = i2c_receive(mpu6050_bus, 104, 61, 1);
+	lowByte = i2c_receive(mpu6050_bus, 104, 62, 1);
 	out->accel[1] = accel_precision_factor*(int16_t)((highByte << 8) | lowByte);
 	//ACCEL Z
-	highByte = i2c_receive(bus, 104, 63, 1);
-	lowByte = i2c_receive(bus, 104, 64, 1);
+	highByte = i2c_receive(mpu6050_bus, 104, 63, 1);
+	lowByte = i2c_receive(mpu6050_bus, 104, 64, 1);
 	out->accel[2] = accel_precision_factor*(int16_t)((highByte << 8) | lowByte);
 }
 
@@ -89,10 +89,10 @@ void readMPUData(struct position_data *position){
 
 void initMPU6050(struct i2c_bus bus_arg, struct position_data callibration_data){
 	
-  bus = bus_arg;
+  	mpu6050_bus = bus_arg;
 
 	//wake up MPU6050 from sleep mode
-	i2c_send(bus, 104, 107, 0, 1);
+	i2c_send(mpu6050_bus, 104, 107, 0, 1);
 
 	mpu_pos_callibration = callibration_data;
 	

--- a/main/i2c_devices/mpu6050.c
+++ b/main/i2c_devices/mpu6050.c
@@ -1,5 +1,5 @@
 
-#include "freertos/FreeRTOS.h"
+
 #include "../helpers/math.h"
 #include "mpu6050.h"
 

--- a/main/i2c_devices/mpu6050.h
+++ b/main/i2c_devices/mpu6050.h
@@ -10,6 +10,6 @@ struct position_data {
 
 void initMPU6050(struct i2c_bus bus_arg, struct position_data callibration_data);
 
-void readMPURawData(struct position_data *out);
+void readMPUData(struct position_data *out);
 
 #endif

--- a/main/i2c_devices/mpu6050.h
+++ b/main/i2c_devices/mpu6050.h
@@ -1,6 +1,7 @@
 #ifndef I2C_DEVICES_MPU6050
 #define I2C_DEVICES_MPU6050
 
+#include "freertos/FreeRTOS.h"
 #include "interchip.h"
 
 struct position_data {

--- a/main/main.c
+++ b/main/main.c
@@ -41,14 +41,14 @@ void app_main(void)
         printf("BMP280 Height: ");
         test = getHeight();
         printf("%f\n", test);
-        /*
+        
         struct position_data position = {
             {0, 0, 0},
             {0, 0, 0}
         };
-        printf("MPU Data: ");
-        readMPURawData(&position);
+        printf("MPU Data: \n");
+        readMPUData(&position);
         printf("(%f, %f, %f), (%f, %f, %f)\n", position.accel[0], position.accel[1],position.accel[2],position.gyro[0], position.gyro[1], position.gyro[2]);
-        */
+        
     }
 }

--- a/main/main.c
+++ b/main/main.c
@@ -7,6 +7,8 @@
 #include "i2c_devices/bmp280.h"
 #include "i2c_devices/mpu6050.h"
 
+#include "helpers/rotation_matrix.h"
+
 struct i2c_bus bus0 = {14, 25};
 struct i2c_bus bus1 = {18, 19};
 
@@ -37,18 +39,23 @@ void app_main(void)
         vTaskDelay(10);
 
         update_bmp280_if_necessary();
+        
+        updateRotationMatrix();
 		
-        printf("BMP280 Height: ");
+        /*printf("BMP280 Height: ");
         test = getHeight();
         printf("%f\n", test);
-        
-        struct position_data position = {
+        */
+        /*struct position_data position = {
             {0, 0, 0},
             {0, 0, 0}
         };
-        printf("MPU Data: \n");
-        readMPUData(&position);
-        printf("(%f, %f, %f), (%f, %f, %f)\n", position.accel[0], position.accel[1],position.accel[2],position.gyro[0], position.gyro[1], position.gyro[2]);
+        */
+        //printf("MPU Data: \n");
+        //readMPUData(&position);
+        //printf("(%f, %f, %f), (%f, %f, %f)\n", position.accel[0], position.accel[1],position.accel[2],position.gyro[0], position.gyro[1], position.gyro[2]);
+        
+        printf("rotation matrix:\n %f, %f, %f\n%f, %f, %f\n%f, %f, %f\n", rotation_matrix[0], rotation_matrix[1], rotation_matrix[2], rotation_matrix[3], rotation_matrix[4], rotation_matrix[5], rotation_matrix[6], rotation_matrix[7], rotation_matrix[8]);
         
     }
 }

--- a/main/main.c
+++ b/main/main.c
@@ -20,7 +20,7 @@ void app_main(void)
         {readEEPROM(3), readEEPROM(4), readEEPROM(5)}
     };
 
-    init_bmp28(bus1, readEEPROM(6));
+    init_bmp280(bus1, readEEPROM(6));
     initMPU6050(bus0, mpu_callibration);
 
     float test;
@@ -29,19 +29,19 @@ void app_main(void)
     test = readEEPROM(0);
     printf("%f\n", test);
 
-    printf("BMP280 Pressure Diff: ");
-    test = getPressureDiff();
-    printf("%f\n", test);
+    //printf("BMP280 Pressure Diff: ");
+    //test = getPressureDiff();
+    //printf("%f\n", test);
 
     while(1) {
         vTaskDelay(10);
 
         update_bmp280_if_necessary();
-
+		
         printf("BMP280 Height: ");
         test = getHeight();
         printf("%f\n", test);
-        
+        /*
         struct position_data position = {
             {0, 0, 0},
             {0, 0, 0}
@@ -49,5 +49,6 @@ void app_main(void)
         printf("MPU Data: ");
         readMPURawData(&position);
         printf("(%f, %f, %f), (%f, %f, %f)\n", position.accel[0], position.accel[1],position.accel[2],position.gyro[0], position.gyro[1], position.gyro[2]);
+        */
     }
 }


### PR DESCRIPTION
BMP280
- bus variable was somehow visible across more files than intended, changed name 
- initialization of smoothed variables with 0 fixed
- raw pressure and temperature readings were mixed up

MPU6050
- changed bus variable name
- added calibration offset code

ROTATION_MATRIX
- added rotation_matrix.c/.h