### PR TITLE
Timer usage fix

### DIFF
--- a/main/control/rotation_matrix.cpp
+++ b/main/control/rotation_matrix.cpp
@@ -60,9 +60,11 @@ void RotationMatrix::update(struct motion_data position) {
     // rotation-matrix:
     // angles in radians
     // 0.01745329 = pi/180
-    float alpha = 0.01745329 * position.gyro[0] * timer.get_laptime();
-    float beta = 0.01745329 * position.gyro[1] * timer.get_laptime();
-    float gamma = 0.01745329 * position.gyro[2] * timer.get_laptime();
+    float alpha = 0.01745329 * position.gyro[0] * timer.get_laptime() * 0.001;
+    float beta = 0.01745329 * position.gyro[1] * timer.get_laptime() * 0.001;
+    float gamma = 0.01745329 * position.gyro[2] * timer.get_laptime() * 0.001;
+
+    timer.reset();
 
     // infinitesimal rotation matrix:
     float diff[9];

--- a/main/helpers/timer.cpp
+++ b/main/helpers/timer.cpp
@@ -6,7 +6,7 @@ void delay_ms(int64_t milliseconds) {
 }
 
 MsTimer::MsTimer() {
-    start_ms = 0.001 * (float) esp_timer_get_time();
+    reset();
 }
 
 float MsTimer::take() {
@@ -20,4 +20,8 @@ bool MsTimer::has_laptime() {
 
 float MsTimer::get_laptime() {
     return laptime_ms;
+}
+
+void MsTimer::reset() {
+    start_ms = 0.001 * (float) esp_timer_get_time();
 }

--- a/main/helpers/timer.h
+++ b/main/helpers/timer.h
@@ -17,6 +17,7 @@ public:
     float take();
     bool has_laptime();
     float get_laptime();
+    void reset();
 };
 
 #endif

--- a/main/i2c/bmp280.cpp
+++ b/main/i2c/bmp280.cpp
@@ -52,7 +52,7 @@ int Bmp280::update_if_possible() {
         current_smoothed_pressure = SMOOTHING_PRESSURE_RECENT_VALUE_WEIGHT * get_pressure() +
                                     (1 - SMOOTHING_PRESSURE_RECENT_VALUE_WEIGHT) * current_smoothed_pressure;
 
-        timer = {};
+        timer.reset();
         start_measurement();
         return 1;
     }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -27,7 +27,7 @@ float z_mapper(float v1, float v2, float v3) { return v3; }
 
 extern "C" _Noreturn void app_main(void) {
 
-    nvs_flash_init(); // Required for WiFi at least.
+    /*nvs_flash_init(); // Required for WiFi at least.
 
     wifi_sta_config_t wifi_config {
             "KiteReceiver",
@@ -39,6 +39,7 @@ extern "C" _Noreturn void app_main(void) {
             },
     };
     init_wifi(wifi_config);
+    */
 
     Cat24c256 storage {cat24c256};
 
@@ -111,10 +112,12 @@ extern "C" _Noreturn void app_main(void) {
 
         /* printf("pwm-input: %f, %f, %f, %f\n", getPWMInputMinus1to1normalized(0), getPWMInputMinus1to1normalized(1), getPWMInputMinus1to1normalized(2), getPWMInputMinus1to1normalized(3)); */
 
+        /*
         myServo.set(0);
         vTaskDelay(200);
         myServo.set(1);
         vTaskDelay(200);
+         */
 
         //setSpeed(0,30);
         //setSpeed(1,60);


### PR DESCRIPTION
In rotation matrix, we multiply degree/sec with sec to get total degreees.
We used to multiply with ms which is wrong.