### PR TITLE
Rotate Towards G Fix

### DIFF
--- a/main/control/rotation_matrix.cpp
+++ b/main/control/rotation_matrix.cpp
@@ -21,8 +21,13 @@ void RotationMatrix::rotate_towards_g(float mat[], float a, float b, float c) {
     axis_3 /= norm;
 
     // determine the approximate angle between mat'*(x_gravity_factor, y_gravity_factor, z_gravity_factor)' and (a,b,c)'
+    // normalize accel vector
+    norm = sqrt(a * a + b * b + c * c);
+    a = a/norm;
+    b = b/norm;
+    c = c/norm;
     float differenceNorm = sqrt(
-            (mat[2] - a) * (mat[2] - a) + (mat[5] - b) * (mat[5] - b) + (mat[8] - c) * (mat[8] - c));
+            (x_gravity_factor - a) * (x_gravity_factor - a) + (y_gravity_factor - b) * (y_gravity_factor - b) + (z_gravity_factor - c) * (z_gravity_factor - c));
     // multiply by small number, so we move only tiny bit in right direction at every step -> averaging measured acceleration from vibration
     float angle = differenceNorm *
                   0.001;//When connected to USB, then 0.00004 suffices. When autonomous on battery 0.0004 (10 times larger) does just fine.


### PR DESCRIPTION
Using real world G and accel values to determine deviation angle (instead of matrix values)

Normalize accel before calculating angle.